### PR TITLE
Fix 307 Temporary Redirect - Actualizar URL entorno test

### DIFF
--- a/lib/todopagoconnector.py
+++ b/lib/todopagoconnector.py
@@ -35,7 +35,7 @@ restAppend = 'api/'
 tenant = 't/1.1/'
 soapAthorizeAppend = 'Authorize'
 end_points_base = {
-	"test" : "https://developers.todopago.com.ar/",
+	"test" : "https://apis.developers.todopago.com.ar/",
 	"prod" : "https://apis.todopago.com.ar/"
 }
 


### PR DESCRIPTION
Al seguir los primeros pasos del readme, para el entorno test salta el error HTTP 307 Temporary redirect, no asi si se usa prod.
La librería `suds` que es dependencia de esta, no sigue las redirecciones.
Haciendo el request de forma manual, la URL base correcta actualmente parece ser apis.developers.todopago.com.ar

![](https://i.imgur.com/mj7s0Pt.png)